### PR TITLE
Fix for breaking dependency reference

### DIFF
--- a/src/main/java/com/dell/isg/smi/service/server/configuration/controller/TrapConfigController.java
+++ b/src/main/java/com/dell/isg/smi/service/server/configuration/controller/TrapConfigController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.dell.isg.smi.adapter.server.model.WsmanCredentials;
 import com.dell.isg.smi.commons.elm.exception.RuntimeCoreException;
-import com.dell.isg.smi.commons.elm.utilities.CustomRecursiveToStringStyle;
+import com.dell.isg.smi.commons.utilities.CustomRecursiveToStringStyle;
 import com.dell.isg.smi.commons.model.common.Credential;
 import com.dell.isg.smi.commons.model.common.ResponseString;
 import com.dell.isg.smi.service.server.configuration.manager.ITrapManager;


### PR DESCRIPTION
Fix for utility that was moved from elm to utilities, and causes break when referencing latest dependencies.